### PR TITLE
Simplify formatting to correct section numbering

### DIFF
--- a/Attendee Procedure for incident handling.md
+++ b/Attendee Procedure for incident handling.md
@@ -1,12 +1,20 @@
 This procedure has been adopted from the Ada Initiative's guide titled "[Conference anti-harassment/Responding to Reports](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports)”.
 
-1. Keep in mind that all conference staff will be wearing a conference t-shirt/button with the word “STAFF” on it (or otherwise clearly marked as staff). The staff will also be prepared to handle the incident.  All of our staff are informed of the [code of conduct policy](/2013/about/code-of-conduct/) and guide for handling harassment at the conference. *There will be a mandatory staff meeting onsite at the conference when this will be reiterated.*
+1\. Keep in mind that all conference staff will be wearing a conference t-shirt/button with the word “STAFF”
+on it (or otherwise clearly marked as staff). The staff will also be prepared to handle the incident.
+All of our staff are informed of the [code of conduct policy](/2013/about/code-of-conduct/) and guide
+for handling harassment at the conference. *There will be a mandatory staff meeting onsite at the conference
+when this will be reiterated.*
 
-2. Report the harassment incident (preferably in writing) to a conference staff member. All reports are confidential. Please do not disclose public information about the incident until the staff have had sufficient time in which to address the situation. This is as much for your safety and protection as it is the other attendees.
+2\. Report the harassment incident (preferably in writing) to a conference staff member. All reports
+are confidential. Please do not disclose public information about the incident until the staff have
+had sufficient time in which to address the situation. This is as much for your safety and protection
+as it is the other attendees.
 
-   When reporting the event to staff, try to gather as much information as available but do not interview people about the incident. Staff will assist you in writing the report/collecting information.
+When reporting the event to staff, try to gather as much information as available but do not
+interview people about the incident. Staff will assist you in writing the report/collecting information.
 
-   The important information consists of:
+The important information consists of:
 
 - Identifying information (name/badge number) of the participant doing the harassing
 - The behavior that was in violation
@@ -16,8 +24,15 @@ This procedure has been adopted from the Ada Initiative's guide titled "[Confere
 
 The staff is well informed on how to deal with the incident and how to further proceed with the situation.
 
-3. If everyone is presently physically safe, involve law enforcement or security only at a victim's request. If you do feel your safety in jeopardy please do not hesitate to contact local law enforcement by dialing 911. If you do not have a cell phone, you can use any hotel phone or simply ask a staff member.
+3\. If everyone is presently physically safe, involve law enforcement or security only at a victim's request.
+If you do feel your safety in jeopardy please do not hesitate to contact local law enforcement by
+dialing 911. If you do not have a cell phone, you can use any hotel phone or simply ask a staff member.
 
-**Note**: Incidents that violate the Code of Conduct are extremely damaging to the community, and they will not be tolerated. The silver lining is that, in many cases, these incidents present a chance for the offenders, and the community at large, to grow, learn, and become better. PyCon staff requests that they be your first resource when reporting a PyCon-related incident, so that they may enforce the Code of Conduct and take quick action toward a resolution.
+**Note**: Incidents that violate the Code of Conduct are extremely damaging to the community, and they
+will not be tolerated. The silver lining is that, in many cases, these incidents present a chance for
+the offenders, and the community at large, to grow, learn, and become better. PyCon staff requests
+that they be your first resource when reporting a PyCon-related incident, so that they may enforce
+the Code of Conduct and take quick action toward a resolution.
 
-A listing of [PyCon staff is located here](/2013/about/staff/), including contact phone numbers. If at all possible, all reports should be made directly to [Ewa Jodlowska](mailto:ewa@python.org) (Event Coordinator) or [Jesse Noller](mailto:jnoller@python.org) (PyCon Chair).
+A listing of [PyCon staff is located here](/2013/about/staff/), including contact phone numbers.
+If at all possible, all reports should be made directly to [Ewa Jodlowska](mailto:ewa@python.org) (Event Coordinator) or [Jesse Noller](mailto:jnoller@python.org) (PyCon Chair).


### PR DESCRIPTION
The third section was being numbered 1. Reading around, it appears
Markdown is bad at handling nested lists with multiple paragraphs.
